### PR TITLE
Disabled accessing the udev log on systemd based systems

### DIFF
--- a/recipes-crosswalk/crosswalk/crosswalk/disable-udev-log.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/disable-udev-log.patch
@@ -1,0 +1,34 @@
+diff --git a/ui/events/ozone/device/udev/device_manager_udev.cc.old b/ui/events/ozone/device/udev/device_manager_udev.cc
+index 7f86bee..f873642 100644
+--- a/ui/events/ozone/device/udev/device_manager_udev.cc
++++ b/ui/events/ozone/device/udev/device_manager_udev.cc
+@@ -33,29 +33,9 @@ enum {
+   SYS_LOG_DEBUG = 7,
+ };
+ 
+-// Log handler for messages generated from libudev.
+-void UdevLog(struct udev* udev,
+-             int priority,
+-             const char* file,
+-             int line,
+-             const char* fn,
+-             const char* format,
+-             va_list args) {
+-  if (priority <= SYS_LOG_ERR)
+-    LOG(ERROR) << "libudev: " << fn << ": " << base::StringPrintV(format, args);
+-  else if (priority <= SYS_LOG_INFO)
+-    VLOG(1) << "libudev: " << fn << ": " << base::StringPrintV(format, args);
+-  else  // SYS_LOG_DEBUG
+-    VLOG(2) << "libudev: " << fn << ": " << base::StringPrintV(format, args);
+-}
+-
+ // Create libudev context.
+ device::ScopedUdevPtr UdevCreate() {
+   struct udev* udev = udev_new();
+-  if (udev) {
+-    udev_set_log_fn(udev, UdevLog);
+-    udev_set_log_priority(udev, SYS_LOG_DEBUG);
+-  }
+   return device::ScopedUdevPtr(udev);
+ }
+ 

--- a/recipes-crosswalk/crosswalk/crosswalk/fix-jpeg-bool-boolean.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/fix-jpeg-bool-boolean.patch
@@ -1,0 +1,49 @@
+diff --git a/ui/gfx/codec/jpeg_codec.cc.orig b/ui/gfx/codec/jpeg_codec.cc
+index 8a08fe0..38d886c 100644
+--- a/ui/gfx/codec/jpeg_codec.cc
++++ b/ui/gfx/codec/jpeg_codec.cc
+@@ -120,7 +120,7 @@ boolean EmptyOutputBuffer(jpeg_compress_struct* cinfo) {
+   // tell libjpeg where to write the next data
+   cinfo->dest->next_output_byte = &(*state->out)[state->image_buffer_used];
+   cinfo->dest->free_in_buffer = state->out->size() - state->image_buffer_used;
+-  return 1;
++  return TRUE;
+ }
+ 
+ // Cleans up the JpegEncoderState to prepare for returning in the final form.
+@@ -261,7 +261,7 @@ bool JPEGCodec::Encode(const unsigned char* input, ColorFormat format,
+   cinfo.data_precision = 8;
+ 
+   jpeg_set_defaults(&cinfo);
+-  jpeg_set_quality(&cinfo, quality, 1);  // quality here is 0-100
++  jpeg_set_quality(&cinfo, quality, TRUE);  // quality here is 0-100
+ 
+   // set up the destination manager
+   jpeg_destination_mgr destmgr;
+@@ -273,7 +273,7 @@ bool JPEGCodec::Encode(const unsigned char* input, ColorFormat format,
+   JpegEncoderState state(output);
+   cinfo.client_data = &state;
+ 
+-  jpeg_start_compress(&cinfo, 1);
++  jpeg_start_compress(&cinfo, TRUE);
+ 
+   // feed it the rows, doing necessary conversions for the color format
+ #ifdef JCS_EXTENSIONS
+@@ -359,7 +359,7 @@ void InitSource(j_decompress_ptr cinfo) {
+ //   set to a positive value if TRUE is returned. A FALSE return should only
+ //   be used when I/O suspension is desired."
+ boolean FillInputBuffer(j_decompress_ptr cinfo) {
+-  return false;
++  return FALSE;
+ }
+ 
+ // Skip data in the buffer. Since we have all the data at once, this operation
+@@ -487,7 +487,7 @@ bool JPEGCodec::Decode(const unsigned char* input, size_t input_size,
+   cinfo.client_data = &state;
+ 
+   // fill the file metadata into our buffer
+-  if (jpeg_read_header(&cinfo, true) != JPEG_HEADER_OK)
++  if (jpeg_read_header(&cinfo, TRUE) != JPEG_HEADER_OK)
+     return false;
+ 
+   // we want to always get RGB data out

--- a/recipes-crosswalk/crosswalk/crosswalk/fix-missing-stat-includes.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/fix-missing-stat-includes.patch
@@ -1,0 +1,14 @@
+diff --git a/components/storage_monitor/storage_monitor_linux.cc.orig b/components/storage_monitor/storage_monitor_linux.cc
+index 6b57f5c..6eb6e1f 100644
+--- a/components/storage_monitor/storage_monitor_linux.cc
++++ b/components/storage_monitor/storage_monitor_linux.cc
+@@ -8,6 +8,9 @@
+ 
+ #include <mntent.h>
+ #include <stdio.h>
++#include <unistd.h>
++#include <sys/stat.h>
++#include <sys/types.h>
+ 
+ #include <list>
+ 

--- a/recipes-crosswalk/crosswalk/crosswalk/fix-strict-overflow-error-bignum.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/fix-strict-overflow-error-bignum.patch
@@ -1,0 +1,18 @@
+diff --git a/third_party/WebKit/Source/wtf/dtoa/bignum.cc.orig b/third_party/WebKit/Source/wtf/dtoa/bignum.cc
+index a000b46..dc2ef1f 100644
+--- a/third_party/WebKit/Source/wtf/dtoa/bignum.cc
++++ b/third_party/WebKit/Source/wtf/dtoa/bignum.cc
+@@ -104,10 +104,10 @@ namespace double_conversion {
+ 
+     void Bignum::AssignDecimalString(Vector<const char> value) {
+         // 2^64 = 18446744073709551616 > 10^19
+-        const int kMaxUint64DecimalDigits = 19;
++        const unsigned int kMaxUint64DecimalDigits = 19;
+         Zero();
+-        int length = value.length();
+-        int pos = 0;
++        unsigned int length = (unsigned int)value.length();
++        unsigned int pos = 0;
+         // Let's just say that each digit needs 4 bits.
+         while (length >= kMaxUint64DecimalDigits) {
+             uint64_t digits = ReadUInt64(value, pos, kMaxUint64DecimalDigits);

--- a/recipes-crosswalk/crosswalk/crosswalk/fix-strict-overflow-error-image.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/fix-strict-overflow-error-image.patch
@@ -1,0 +1,45 @@
+diff --git a/ui/gfx/image/image_util.cc.orig b/ui/gfx/image/image_util.cc
+index 89a3f8c..cdc11eb 100644
+--- a/ui/gfx/image/image_util.cc
++++ b/ui/gfx/image/image_util.cc
+@@ -65,31 +65,31 @@ bool VisibleMargins(const ImageSkia& image, int* leading, int* trailing) {
+     return true;
+ 
+   SkAutoLockPixels l(bitmap);
+-  int inner_min = bitmap.width();
+-  for (int x = 0; x < bitmap.width(); ++x) {
+-    for (int y = 0; y < bitmap.height(); ++y) {
++  unsigned int inner_min = (unsigned int)bitmap.width();
++  for (unsigned int x = 0; x < (unsigned int)bitmap.width(); ++x) {
++    for (unsigned int y = 0; y < (unsigned int)bitmap.height(); ++y) {
+       if (SkColorGetA(bitmap.getColor(x, y)) > kMinimumVisibleOpacity) {
+         inner_min = x;
+         break;
+       }
+     }
+-    if (inner_min < bitmap.width())
++    if (inner_min < (unsigned int)bitmap.width())
+       break;
+   }
+ 
+-  int inner_max = -1;
+-  for (int x = bitmap.width() - 1; x > inner_min; --x) {
+-    for (int y = 0; y < bitmap.height(); ++y) {
++  unsigned int inner_max = -1;
++  for (unsigned int x = (unsigned int)bitmap.width() - 1; x > inner_min; --x) {
++    for (unsigned int y = 0; y < (unsigned int)bitmap.height(); ++y) {
+       if (SkColorGetA(bitmap.getColor(x, y)) > kMinimumVisibleOpacity) {
+         inner_max = x;
+         break;
+       }
+     }
+-    if (inner_max > -1)
++    if (inner_max != (unsigned int)-1)
+       break;
+   }
+ 
+-  if (inner_min == bitmap.width()) {
++  if (inner_min == (unsigned int)bitmap.width()) {
+     *leading = bitmap.width()/2;
+     *trailing = bitmap.width()/2 + 1;
+     return true;

--- a/recipes-crosswalk/crosswalk/crosswalk_12.40.295.0.bbappend
+++ b/recipes-crosswalk/crosswalk/crosswalk_12.40.295.0.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
     file://do_not_force_glib.patch \
     file://xwalk \
     file://wayland-egl-fix.patch \
+    ${@base_contains('DISTRO_FEATURES', 'systemd', 'file://disable-udev-log.patch', '', d)} \
     "
 
 DEPENDS_remove = "gtk+"

--- a/recipes-crosswalk/crosswalk/crosswalk_12.40.295.0.bbappend
+++ b/recipes-crosswalk/crosswalk/crosswalk_12.40.295.0.bbappend
@@ -2,10 +2,14 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/crosswalk:"
 
 SRC_URI += " \
     file://build_fix.patch \
-    file://do_not_force_glib.patch \
-    file://xwalk \
-    file://wayland-egl-fix.patch \
     ${@base_contains('DISTRO_FEATURES', 'systemd', 'file://disable-udev-log.patch', '', d)} \
+    file://do_not_force_glib.patch \
+    file://fix-jpeg-bool-boolean.patch \
+    file://fix-missing-stat-includes.patch \
+    file://fix-strict-overflow-error-bignum.patch \
+    file://fix-strict-overflow-error-image.patch \
+    file://wayland-egl-fix.patch \
+    file://xwalk \
     "
 
 DEPENDS_remove = "gtk+"


### PR DESCRIPTION
Recent versions of systemd ship a libudev that [deprecated `udev_set_log_fn`](https://github.com/systemd/systemd/commit/25e773eeb4f853804e1bf0dbd9a184f23e9b2a97) and [stubbed away](https://github.com/systemd/systemd/blob/master/src/libudev/libudev.c#L225) the implementation.

This patch removes the code from crosswalk that otherwise breaks the build due to deprecated warnings being errors. With the change, crosswalk runs on Yocto "Fido" with systemd.
